### PR TITLE
Added the possibility to build the static cosoco library without having the XCSP3 parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 main/cosoco
 main/cosoco.*
 
+# the clangd cache
+.cache
+# the build folder
+build
+# the default cmake makefile
+Makefile
+
 
 
 # instances

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,19 +3,25 @@ cmake_minimum_required(VERSION 3.3)
 #set(CMAKE_CXX_COMPILER "g++-7")
 project(cosoco)
 
+# Check if the 'no-xcsp3' option is enabled
+option(NO_XCSP3 "Disable XCSP3 support" OFF)
 
+# define some dirs
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/main")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/lib")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/lib)
 
-
+# define some c++ flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wno-parentheses -Wall -O3 -Wno-unused-label")
 
-include_directories(/usr/local/opt/libxml2/include/libxml2/)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
-find_package(LibXml2 REQUIRED)
-include_directories(${LIBXML2_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+if(NOT NO_XCSP3)
+    #if we're not using xcsp, don't include libxml2
+    include_directories(/usr/local/opt/libxml2/include/libxml2/)
+    find_package(LibXml2 REQUIRED)
+    include_directories(${LIBXML2_INCLUDE_DIRS})
+endif()
 
 file(GLOB_RECURSE Cosoco_SOURCES
         ${PROJECT_SOURCE_DIR}/constraints/*.cc
@@ -40,7 +46,6 @@ file(GLOB_RECURSE Cosoco_HEADERS
 
 set(LIBRARY_NAME libcosoco)
 
-
 file(GLOB_RECURSE Cosoco_HEADERS "./*.h")
 
 set(Cosoco_INCLUDE_DIRS "")
@@ -54,25 +59,30 @@ list(REMOVE_DUPLICATES Cosoco_INCLUDE_DIRS)
 
 include_directories(
         ${Cosoco_INCLUDE_DIRS}
-        ${CMAKE_CURRENT_SOURCE_DIR}/../XCSP3-CPP-Parser/include/
 )
-
 
 add_library(${LIBRARY_NAME} STATIC ${Cosoco_SOURCES}
         solver/utils/Profiling.cc)
 
+if(NOT NO_XCSP3)
+    include_directories(
+            ${CMAKE_CURRENT_SOURCE_DIR}/../XCSP3-CPP-Parser/include/
+    )
 
-link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../XCSP3-CPP-Parser/lib)
+    link_directories(${CMAKE_CURRENT_SOURCE_DIR}/../XCSP3-CPP-Parser/lib)
+    target_compile_definitions(${LIBRARY_NAME} PRIVATE USE_XCSP3)
+endif()
 
 set_target_properties(${LIBRARY_NAME} PROPERTIES OUTPUT_NAME "cosoco")
 
-
-link_libraries(xcsp3parser)
-add_executable(cosoco main/Main.cc
-        mtl/Matrix.h)
-target_link_libraries(cosoco ${LIBRARY_NAME})
-target_link_libraries(cosoco ${LIBXML2_LIBRARIES})
-
-
-target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
-
+if(NOT NO_XCSP3)
+    link_libraries(xcsp3parser)
+    add_executable(cosoco main/Main.cc
+            mtl/Matrix.h)
+    target_compile_definitions(cosoco PRIVATE USE_XCSP3)
+    target_link_libraries(cosoco ${LIBRARY_NAME})
+    target_link_libraries(cosoco ${LIBXML2_LIBRARIES})
+    
+    
+    target_include_directories(${LIBRARY_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+endif()

--- a/build-lib.sh
+++ b/build-lib.sh
@@ -1,0 +1,3 @@
+cmake -DNO_XCSP3=ON -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" .
+#cmake -DCMAKE_BUILD_TYPE=Debug -G "Unix Makefiles" .
+cmake --build . --target libcosoco -- -j 8

--- a/constraints/Constraint.cc
+++ b/constraints/Constraint.cc
@@ -4,11 +4,16 @@
 
 #include <utility>
 
+#ifdef USE_XCSP3
 #include "XCSP3Tree.h"
 #include "mtl/Map.h"
 #include "solver/utils/FactoryConstraints.h"
 #include "utils/Utils.h"
+#else
+#include "utils/Options.h"
+#endif /* #ifdef USE_XCSP3 */
 
+#include "core/Problem.h"
 
 using namespace std;
 using namespace Cosoco;
@@ -154,6 +159,7 @@ void Constraint::extractConstraintTupleFromInterpretation(const vec<int> &interp
     }
 }
 
+#ifdef USE_XCSP3
 
 void createTuples(int posx, vec<Variable *> &scope, XCSP3Core::Tree *tree, vec<vec<int>> &conflicts, vec<vec<int>> &supports,
                   std::map<string, int> &tuple) {
@@ -162,8 +168,8 @@ void createTuples(int posx, vec<Variable *> &scope, XCSP3Core::Tree *tree, vec<v
 
     for(int i = 0; i < x->domain.maxSize(); i++) {
         tuple[x->_name] = x->domain.toVal(i);
-        if(posx == scope.size() - 2 && tree->root->type == OEQ && tree->root->parameters[1]->type == OVAR) {
-            auto *nv = dynamic_cast<NodeVariable *>(tree->root->parameters[1]);
+        if(posx == scope.size() - 2 && tree->root->type == XCSP3Core::OEQ && tree->root->parameters[1]->type == XCSP3Core::OVAR) {
+            auto *nv = dynamic_cast<XCSP3Core::NodeVariable *>(tree->root->parameters[1]);
             if(nodeContainsVar(tree->root->parameters[0], nv->var) == false) {
                 // we have expr = var
                 // we evaluate the expression and put the value in support
@@ -207,6 +213,7 @@ void Constraint::toExtensionConstraint(XCSP3Core::Tree *tree, vec<Variable *> &s
     }
 }
 
+#endif /* USE_XCSP3 */
 
 // Display
 void Constraint::display(bool allDetails) {

--- a/constraints/Constraint.h
+++ b/constraints/Constraint.h
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <string>
 
-#include "XCSP3Tree.h"
 #include "core/Problem.h"
 #include "core/Variable.h"
 #include "mtl/SparseSet.h"
@@ -13,6 +12,14 @@
 
 
 #define NOTINSCOPE -1
+
+#ifdef USE_XCSP3
+#include <vector>
+namespace XCSP3Core {
+class Tree;
+}
+#endif
+
 namespace Cosoco {
 
 enum State { CONSISTENT, INCONSISTENT, UNDEF };
@@ -88,8 +95,10 @@ class Constraint {
     // Display
     virtual void display(bool allDetails = false);
     virtual void attachSolver(Solver *s);
-    static void  toExtensionConstraint(XCSP3Core::Tree *tree, vec<Variable *> &scope, std::vector<std::vector<int> > &tuples,
-                                       bool &isSupport);   // Extract Extensional . Return nullptr if too many tuples
+#ifdef USE_XCSP3
+    static void toExtensionConstraint(XCSP3Core::Tree *tree, vec<Variable *> &scope, std::vector<std::vector<int> > &tuples,
+                                      bool &isSupport);   // Extract Extensional . Return nullptr if too many tuples
+#endif
 
    protected:
     // All this part simplify scope initialisation

--- a/constraints/extensions/Extension.h
+++ b/constraints/extensions/Extension.h
@@ -10,8 +10,8 @@
 
 
 #include "Matrix.h"
-#include "XCSP3Constants.h"
 #include "constraints/Constraint.h"
+#include "utils/Constants.h"
 
 namespace Cosoco {
 class Extension : public Constraint {

--- a/constraints/extensions/MDDExtension.cc
+++ b/constraints/extensions/MDDExtension.cc
@@ -1,5 +1,7 @@
 #include "MDDExtension.h"
 
+#ifdef USE_XCSP3
+
 #include "constraints/extensions/structures/MDD.h"
 #include "solver/Solver.h"
 
@@ -148,3 +150,5 @@ void MDDExtension::attachSolver(Solver *s) {
 
 
 void MDDExtension::notifyDeleteDecision(Variable *x, int v, Solver &s) { falseTimestamp++; }
+
+#endif /* USE_XCSP3 */

--- a/constraints/extensions/MDDExtension.h
+++ b/constraints/extensions/MDDExtension.h
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef COSOCO_MDDEXTENSION_H
 #define COSOCO_MDDEXTENSION_H
 
+#ifdef USE_XCSP3
 
 #include "Extension.h"
 #include "solver/observers/ObserverDecision.h"
@@ -36,5 +38,7 @@ class MDDExtension : public Extension, ObserverDeleteDecision {
     bool manageSuccessfulExploration(Variable *x, int idv, int level);
 };
 }   // namespace Cosoco
+
+#endif /* USE_XCSP3 */
 
 #endif   // COSOCO_MDDEXTENSION_H

--- a/constraints/extensions/ShortSTR2.cc
+++ b/constraints/extensions/ShortSTR2.cc
@@ -1,8 +1,8 @@
 #include "ShortSTR2.h"
 
-#include "XCSP3Constants.h"
 #include "mtl/Matrix.h"
 #include "solver/Solver.h"
+#include "utils/Constants.h"
 // TODO restore lastsize when backtracking
 
 using namespace Cosoco;

--- a/constraints/extensions/structures/MDD.cc
+++ b/constraints/extensions/structures/MDD.cc
@@ -1,10 +1,11 @@
 #include "MDD.h"
 
+#ifdef USE_XCSP3
+
 #include <map>
 #include <new>
 #include <set>
 
-#include "MDD.h"
 using namespace Cosoco;
 
 
@@ -170,3 +171,5 @@ bool MDDNode::isRoot() const { return level == 0; }
 MDDNode::MDDNode(std::string n, int _id, int lvl, int maxNbChilds) : id(_id), level(lvl), name(n) {
     childs.growTo(maxNbChilds, nullptr);
 }
+
+#endif /* USE_XCSP3 */

--- a/constraints/extensions/structures/MDD.h
+++ b/constraints/extensions/structures/MDD.h
@@ -1,6 +1,8 @@
+#pragma once
 #ifndef COSOCO_MDD_H
 #define COSOCO_MDD_H
 
+#ifdef USE_XCSP3
 
 #include <core/Variable.h>
 #include <mtl/Vec.h>
@@ -47,5 +49,6 @@ class MDD {
 };
 }   // namespace Cosoco
 
+#endif /* USE_XCSP3 */
 
 #endif   // COSOCO_MDD_H

--- a/constraints/globals/connection/element/ElementVariable.cc
+++ b/constraints/globals/connection/element/ElementVariable.cc
@@ -1,8 +1,7 @@
 #include "ElementVariable.h"
 
-#include <XCSP3Constants.h>
-
 #include "solver/Solver.h"
+#include "utils/Constants.h"
 
 using namespace Cosoco;
 

--- a/constraints/intension/Intension.cc
+++ b/constraints/intension/Intension.cc
@@ -1,6 +1,8 @@
 #include "constraints/intension/Intension.h"
 
-#include <constraints/genericFiltering/TupleIteratorWithoutOrder.h>
+#ifdef USE_XCSP3
+#include "XCSP3Tree.h"
+
 
 using namespace Cosoco;
 
@@ -36,8 +38,8 @@ bool Intension::filter(Variable *dummy) {
 
 
 void Intension::updateBound(long bound) {
-    auto *nodeB = dynamic_cast<NodeBinary *>(evaluator->root);
-    auto *nodeC = dynamic_cast<NodeConstant *>(nodeB->parameters[1]);
+    auto *nodeB = dynamic_cast<XCSP3Core::NodeBinary *>(evaluator->root);
+    auto *nodeC = dynamic_cast<XCSP3Core::NodeConstant *>(nodeB->parameters[1]);
     nodeC->val  = bound;
 }
 
@@ -51,9 +53,11 @@ long Intension::minLowerBound() { return INT_MIN + 10; }
 long Intension::computeScore(vec<int> &solution) {
     assert(solution.size() == scope.size());
     for(int i = 0; i < scope.size(); i++) tuple[scope[i]->_name] = solution[i];
-    auto *nodeB = dynamic_cast<NodeBinary *>(evaluator->root);
+    auto *nodeB = dynamic_cast<XCSP3Core::NodeBinary *>(evaluator->root);
     return nodeB->parameters[0]->evaluate(tuple);
 }
 
 
 void Intension::display(bool d) { std::cout << evaluator->toString() << std::endl; }
+
+#endif /* USE_XCSP3 */

--- a/constraints/intension/Intension.h
+++ b/constraints/intension/Intension.h
@@ -1,18 +1,28 @@
 #ifndef INTENSION_H
 #define INTENSION_H
 
-#include "XCSP3Tree.h"
+#ifdef USE_XCSP3
+#include <map>
+
 #include "constraints/Constraint.h"
-using namespace XCSP3Core;
+#include "optimizer/ObjectiveConstraint.h"
+
+
+namespace XCSP3Core {
+class Tree;
+}
+
+
 namespace Cosoco {
 class Intension : public Constraint, public ObjectiveConstraint {
    protected:
-    Tree *                     evaluator;
+    XCSP3Core::Tree           *evaluator;
     std::map<std::string, int> tuple;
 
    public:
     // Constructors
-    Intension(Problem &p, std::string n, Tree *tree, vec<Variable *> &scope) : Constraint(p, n, scope), evaluator(tree) {
+    Intension(Problem &p, std::string n, XCSP3Core::Tree *tree, vec<Variable *> &scope)
+        : Constraint(p, n, scope), evaluator(tree) {
         type = "Intension";
     }
 
@@ -39,5 +49,5 @@ class Intension : public Constraint, public ObjectiveConstraint {
 };
 }   // namespace Cosoco
 
-
+#endif /* USE_XCSP3 */
 #endif /* INTENSION_H */

--- a/mtl/Matrix.h
+++ b/mtl/Matrix.h
@@ -9,7 +9,8 @@
 #include <vector>
 
 #include "Vec.h"
-#include "XCSP3Constants.h"
+#include "utils/Constants.h"
+
 namespace Cosoco {
 template <class T>
 class Matrix {

--- a/optimizer/Optimizer.cc
+++ b/optimizer/Optimizer.cc
@@ -1,9 +1,8 @@
 #include "Optimizer.h"
 
-#include <XCSP3Constants.h>
-
 #include "Options.h"
 #include "core/OptimizationProblem.h"
+#include "utils/Constants.h"
 #include "utils/System.h"
 
 using namespace Cosoco;

--- a/optimizer/Solution.h
+++ b/optimizer/Solution.h
@@ -1,16 +1,16 @@
 #ifndef COSOCO_SOLUTION_H
 #define COSOCO_SOLUTION_H
 
-#include <XCSP3Constants.h>
-#include <core/OptimizationProblem.h>
-#include <utils/System.h>
-
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <vector>
 
 #include "Termcolor.h"
+#include "core/OptimizationProblem.h"
 #include "mtl/Vec.h"
+#include "utils/Constants.h"
+#include "utils/System.h"
 
 
 namespace Cosoco {

--- a/solver/heuristics/values/HeuristicValASGS.h
+++ b/solver/heuristics/values/HeuristicValASGS.h
@@ -7,12 +7,12 @@
 
 #include "HeuristicVal.h"
 
-using namespace Cosoco;
+namespace Cosoco {
 class HeuristicValASGS : public HeuristicVal {
    public:
     explicit HeuristicValASGS(Solver &s);
-    
+
     int select(Variable *x) override;
 };
-
+}   // namespace Cosoco
 #endif   // COSOCO_HEURISTICVALASGS_H

--- a/solver/nogoods/NoGoodsEngine.cc
+++ b/solver/nogoods/NoGoodsEngine.cc
@@ -4,6 +4,8 @@
 
 #include "NoGoodsEngine.h"
 
+#include <cmath>
+
 #include "System.h"
 using namespace Cosoco;
 

--- a/solver/utils/CosocoCallbacks.cc
+++ b/solver/utils/CosocoCallbacks.cc
@@ -1,8 +1,15 @@
 #include "CosocoCallbacks.h"
 
+
+#ifdef USE_XCSP3
+#include <vector>
+
+#include "core/OptimizationProblem.h"
+#include "core/domain/DomainValues.h"
+
 using namespace Cosoco;
 
-void CosocoCallbacks::beginInstance(InstanceType type) {
+void XCSP3Core::CosocoCallbacks::beginInstance(InstanceType type) {
     problem = type == CSP ? new Problem("") : new OptimizationProblem("");
     problems.push(problem);
     decisionVariables.growTo(nbcores);
@@ -18,14 +25,14 @@ void CosocoCallbacks::beginInstance(InstanceType type) {
     recognizeSpecialIntensionCases = false;
 }
 
-void CosocoCallbacks::endInstance() {
+void XCSP3Core::CosocoCallbacks::endInstance() {
     if(auxiliaryIdx > 0)
         std::cout << "c " << auxiliaryIdx << " auxiliary variables\n";
     problem->delayedConstruction();
     printf("c nb Intensions -> Extensions : %d (shared: %d)\n", nbIntension2Extention, nbSharedIntension2Extension);
 }
 
-void CosocoCallbacks::buildVariableInteger(string id, int minValue, int maxValue) {
+void XCSP3Core::CosocoCallbacks::buildVariableInteger(string id, int minValue, int maxValue) {
     Variable *x =
         problem->createVariable(id, *(new DomainRange(minValue, maxValue)), inArray ? problem->variablesArray.size() - 1 : -1);
     if(inArray)
@@ -33,7 +40,7 @@ void CosocoCallbacks::buildVariableInteger(string id, int minValue, int maxValue
     mappingXV[id] = new XVariable(id, nullptr);
 }
 
-void CosocoCallbacks::buildVariableInteger(string id, vector<int> &values) {
+void XCSP3Core::CosocoCallbacks::buildVariableInteger(string id, vector<int> &values) {
     Variable *x =
         problem->createVariable(id, *(new DomainValue(vector2vec(values))), inArray ? problem->variablesArray.size() - 1 : -1);
     if(inArray)
@@ -41,50 +48,50 @@ void CosocoCallbacks::buildVariableInteger(string id, vector<int> &values) {
     mappingXV[id] = new XVariable(id, nullptr);
 }
 
-void CosocoCallbacks::beginVariableArray(string id) {
+void XCSP3Core::CosocoCallbacks::beginVariableArray(string id) {
     for(int core = 0; core < nbcores; core++) problem->variablesArray.push();
     inArray = true;
 }
 
-void CosocoCallbacks::endVariableArray() { inArray = false; }
+void XCSP3Core::CosocoCallbacks::endVariableArray() { inArray = false; }
 
-void CosocoCallbacks::endVariables() {
+void XCSP3Core::CosocoCallbacks::endVariables() {
     nbInitialsVariables     = problem->nbVariables();
     problem->nbOriginalVars = problem->nbVariables();
 }
 
-void CosocoCallbacks::initGroups() {
+void XCSP3Core::CosocoCallbacks::initGroups() {
     insideGroup = true;
     nbMDD       = 0;
     nbIntension = -1;
 }
 
 
-void CosocoCallbacks::beginGroup(string name) { initGroups(); }
+void XCSP3Core::CosocoCallbacks::beginGroup(string name) { initGroups(); }
 
 
-void CosocoCallbacks::endGroup() { insideGroup = false; }
+void XCSP3Core::CosocoCallbacks::endGroup() { insideGroup = false; }
 
 
-void CosocoCallbacks::beginSlide(string id, bool circular) { initGroups(); }
+void XCSP3Core::CosocoCallbacks::beginSlide(string id, bool circular) { initGroups(); }
 
 
-void CosocoCallbacks::endSlide() {
+void XCSP3Core::CosocoCallbacks::endSlide() {
     insideGroup = false;
     initGroups();
 }
 
 
-void CosocoCallbacks::beginBlock(string classes) { initGroups(); }
+void XCSP3Core::CosocoCallbacks::beginBlock(string classes) { initGroups(); }
 
 
-void CosocoCallbacks::endBlock() {
+void XCSP3Core::CosocoCallbacks::endBlock() {
     initGroups();
     insideGroup = false;
 }
 
 
-void CosocoCallbacks::beginObjectives() { startToParseObjective = true; }
+void XCSP3Core::CosocoCallbacks::beginObjectives() { startToParseObjective = true; }
 
 
 //--------------------------------------------------------------------------------------
@@ -92,20 +99,21 @@ void CosocoCallbacks::beginObjectives() { startToParseObjective = true; }
 //--------------------------------------------------------------------------------------
 
 
-void CosocoCallbacks::buildConstraintExtension(string id, vector<XVariable *> list, vector<vector<int>> &origTuples, bool support,
-                                               bool hasStar) {
+void XCSP3Core::CosocoCallbacks::buildConstraintExtension(string id, vector<XVariable *> list, vector<vector<int>> &origTuples,
+                                                          bool support, bool hasStar) {
     if(hasStar && !support)
         throw runtime_error("Extension constraint with star and conflict tuples is not yet supported");
     toMyVariables(list);
     buildConstraintExtension2(id, vars, origTuples, support, hasStar);
 }
 
-void CosocoCallbacks::buildConstraintExtensionAs(string id, vector<XVariable *> list, bool support, bool hasStar) {
+void XCSP3Core::CosocoCallbacks::buildConstraintExtensionAs(string id, vector<XVariable *> list, bool support, bool hasStar) {
     FactoryConstraints::createConstraintExtensionAs(problem, id, toMyVariables(list), problem->constraints.last());
 }
 
-void CosocoCallbacks::buildConstraintExtension2(const string &id, vec<Variable *> &scope, const vector<vector<int>> &origTuples,
-                                                bool support, bool hasStar) const {
+void XCSP3Core::CosocoCallbacks::buildConstraintExtension2(const string &id, vec<Variable *> &scope,
+                                                           const vector<vector<int>> &origTuples, bool support,
+                                                           bool hasStar) const {
     vec<vec<int>> tuples;
     tuples.growTo(origTuples.size());
 
@@ -119,7 +127,8 @@ void CosocoCallbacks::buildConstraintExtension2(const string &id, vec<Variable *
 }
 
 
-void CosocoCallbacks::buildConstraintExtension(string id, XVariable *variable, vector<int> &tuples, bool support, bool hasStar) {
+void XCSP3Core::CosocoCallbacks::buildConstraintExtension(string id, XVariable *variable, vector<int> &tuples, bool support,
+                                                          bool hasStar) {
     if(hasStar)
         throw runtime_error("Extension constraint with star is not yet supported");
 
@@ -127,9 +136,10 @@ void CosocoCallbacks::buildConstraintExtension(string id, XVariable *variable, v
 }
 
 
-void CosocoCallbacks::buildConstraintIntension(string id, Tree *tree) { manageIntension->intension(id, tree); }
+void XCSP3Core::CosocoCallbacks::buildConstraintIntension(string id, Tree *tree) { manageIntension->intension(id, tree); }
 
-void CosocoCallbacks::buildConstraintPrimitive(string id, OrderType op, XVariable *x, int k, XVariable *y) {   // x + k op y
+void XCSP3Core::CosocoCallbacks::buildConstraintPrimitive(string id, OrderType op, XVariable *x, int k,
+                                                          XVariable *y) {   // x + k op y
     assert(op == LE || op == LT || op == EQ || op == NE);
 
 
@@ -161,7 +171,8 @@ void CosocoCallbacks::buildConstraintPrimitive(string id, OrderType op, XVariabl
     buildConstraintIntension(id, new Tree(tmp));   // TODO
 }
 
-void CosocoCallbacks::buildConstraintPrimitive(string id, OrderType op, XVariable *xx, int k) {   // x op k op is <= or >=
+void XCSP3Core::CosocoCallbacks::buildConstraintPrimitive(string id, OrderType op, XVariable *xx,
+                                                          int k) {   // x op k op is <= or >=
     Variable *x = problem->mapping[xx->id];
     vec<int>  values;
     for(int idv : x->domain) {
@@ -172,8 +183,8 @@ void CosocoCallbacks::buildConstraintPrimitive(string id, OrderType op, XVariabl
     FactoryConstraints::createConstraintUnary(problem, id, x, values, true);
 }
 
-void CosocoCallbacks::buildConstraintPrimitive(string id, XVariable *xx, bool in, int min,
-                                               int max) {   // x in/notin [min,max]
+void XCSP3Core::CosocoCallbacks::buildConstraintPrimitive(string id, XVariable *xx, bool in, int min,
+                                                          int max) {   // x in/notin [min,max]
     Variable *x = problem->mapping[xx->id];
     vec<int>  values;
     for(int idv : x->domain) {
@@ -185,7 +196,7 @@ void CosocoCallbacks::buildConstraintPrimitive(string id, XVariable *xx, bool in
 }
 
 
-void CosocoCallbacks::buildConstraintMult(string id, XVariable *x, XVariable *y, XVariable *z) {
+void XCSP3Core::CosocoCallbacks::buildConstraintMult(string id, XVariable *x, XVariable *y, XVariable *z) {
     if(x == y || x == z || y == z) {
         cout << "eq(" + z->id + ",mul(" + x->id + "," + y->id + "))\n";
         buildConstraintIntension(id, new Tree("eq(" + z->id + ",mul(" + x->id + "," + y->id + "))"));
@@ -201,7 +212,7 @@ void CosocoCallbacks::buildConstraintMult(string id, XVariable *x, XVariable *y,
 // Language  constraints
 //--------------------------------------------------------------------------------------
 
-Cosoco::MDD *CosocoCallbacks::sameMDDAsPrevious(vec<Variable *> &list) {
+Cosoco::MDD *XCSP3Core::CosocoCallbacks::sameMDDAsPrevious(vec<Variable *> &list) {
     if(insideGroup && nbMDD) {   // Check is the MDD is the same
         auto *ext = dynamic_cast<MDDExtension *>(problem->constraints.last());
         assert(ext != nullptr);
@@ -220,7 +231,7 @@ Cosoco::MDD *CosocoCallbacks::sameMDDAsPrevious(vec<Variable *> &list) {
 }
 
 
-void CosocoCallbacks::buildConstraintMDD(string id, vector<XVariable *> &list, vector<XTransition> &transitions) {
+void XCSP3Core::CosocoCallbacks::buildConstraintMDD(string id, vector<XVariable *> &list, vector<XTransition> &transitions) {
     toMyVariables(list, vars);
     Cosoco::MDD *mdd = nullptr;
     if((mdd = sameMDDAsPrevious(vars)) != nullptr)
@@ -234,8 +245,8 @@ void CosocoCallbacks::buildConstraintMDD(string id, vector<XVariable *> &list, v
 }
 
 
-void CosocoCallbacks::buildConstraintRegular(string id, vector<XVariable *> &list, string start, vector<string> &final,
-                                             vector<XTransition> &transitions) {
+void XCSP3Core::CosocoCallbacks::buildConstraintRegular(string id, vector<XVariable *> &list, string start, vector<string> &final,
+                                                        vector<XTransition> &transitions) {
     toMyVariables(list, vars);
 
     // Some variables can appear multiple times.... We replace by a new variable and an allequal
@@ -276,7 +287,7 @@ void CosocoCallbacks::buildConstraintRegular(string id, vector<XVariable *> &lis
 // Graph constraints
 //--------------------------------------------------------------------------------------
 
-void CosocoCallbacks::buildConstraintCircuit(string id, vector<XVariable *> &list, int startIndex) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCircuit(string id, vector<XVariable *> &list, int startIndex) {
     if(startIndex != 0)
         throw runtime_error("Circuit with startIndex != 0 is not yet supported");
 
@@ -289,16 +300,16 @@ void CosocoCallbacks::buildConstraintCircuit(string id, vector<XVariable *> &lis
 // Comparison constraints
 //--------------------------------------------------------------------------------------
 
-void CosocoCallbacks::buildConstraintAlldifferent(string id, vector<XVariable *> &list) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAlldifferent(string id, vector<XVariable *> &list) {
     FactoryConstraints::createConstraintAllDiff(problem, id, toMyVariables(list));
 }
 
 
-void CosocoCallbacks::buildConstraintAlldifferentExcept(string id, vector<XVariable *> &list, vector<int> &except) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAlldifferentExcept(string id, vector<XVariable *> &list, vector<int> &except) {
     FactoryConstraints::createConstraintAllDiffExcept(problem, id, toMyVariables(list), except);
 }
 
-void CosocoCallbacks::buildConstraintAlldifferent(string id, vector<Tree *> &trees) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAlldifferent(string id, vector<Tree *> &trees) {
     vector<string> auxiliaryVariables;
     insideGroup = false;
     createAuxiliaryVariablesAndExpressions(trees, auxiliaryVariables);
@@ -326,7 +337,7 @@ void CosocoCallbacks::buildConstraintAlldifferent(string id, vector<Tree *> &tre
 }
 
 
-void CosocoCallbacks::buildConstraintAlldifferentList(string id, vector<vector<XVariable *>> &origlists) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAlldifferentList(string id, vector<vector<XVariable *>> &origlists) {
     vec<vec<Variable *>> lists;
     for(auto &origlist : origlists) {
         lists.push();
@@ -336,7 +347,7 @@ void CosocoCallbacks::buildConstraintAlldifferentList(string id, vector<vector<X
 }
 
 
-void CosocoCallbacks::buildConstraintAlldifferentMatrix(string id, vector<vector<XVariable *>> &matrix) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAlldifferentMatrix(string id, vector<vector<XVariable *>> &matrix) {
     // lines
     for(auto &list : matrix) buildConstraintAlldifferent(id, list);
 
@@ -349,28 +360,29 @@ void CosocoCallbacks::buildConstraintAlldifferentMatrix(string id, vector<vector
 }
 
 
-void CosocoCallbacks::buildConstraintAllEqual(string id, vector<XVariable *> &list) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAllEqual(string id, vector<XVariable *> &list) {
     FactoryConstraints::createConstraintAllEqual(problem, id, toMyVariables(list));
 }
 
 
-void CosocoCallbacks::buildConstraintNotAllEqual(string id, vector<XVariable *> &list) {
+void XCSP3Core::CosocoCallbacks::buildConstraintNotAllEqual(string id, vector<XVariable *> &list) {
     FactoryConstraints::createConstraintNotAllEqual(problem, id, toMyVariables(list));
 }
 
 
-void CosocoCallbacks::buildConstraintOrdered(string id, vector<XVariable *> &list, OrderType order) {
+void XCSP3Core::CosocoCallbacks::buildConstraintOrdered(string id, vector<XVariable *> &list, OrderType order) {
     vector<int> lengths;
     FactoryConstraints::createConstraintOrdered(problem, id, toMyVariables(list), lengths, order);
 }
 
 
-void CosocoCallbacks::buildConstraintOrdered(string id, vector<XVariable *> &list, vector<int> &lengths, OrderType order) {
+void XCSP3Core::CosocoCallbacks::buildConstraintOrdered(string id, vector<XVariable *> &list, vector<int> &lengths,
+                                                        OrderType order) {
     FactoryConstraints::createConstraintOrdered(problem, id, toMyVariables(list), lengths, order);
 }
 
 
-void CosocoCallbacks::buildConstraintLex(string id, vector<vector<XVariable *>> &lists, OrderType order) {
+void XCSP3Core::CosocoCallbacks::buildConstraintLex(string id, vector<vector<XVariable *>> &lists, OrderType order) {
     vec<Variable *> list1, list2;
     for(unsigned int i = 0; i < lists.size() - 1; i++) {
         toMyVariables(lists[i], list1);
@@ -380,7 +392,7 @@ void CosocoCallbacks::buildConstraintLex(string id, vector<vector<XVariable *>> 
 }
 
 
-void CosocoCallbacks::buildConstraintLexMatrix(string id, vector<vector<XVariable *>> &matrix, OrderType order) {
+void XCSP3Core::CosocoCallbacks::buildConstraintLexMatrix(string id, vector<vector<XVariable *>> &matrix, OrderType order) {
     // lines
     buildConstraintLex(id, matrix, order);
 
@@ -399,21 +411,22 @@ void CosocoCallbacks::buildConstraintLexMatrix(string id, vector<vector<XVariabl
 // Summing and counting constraints
 //--------------------------------------------------------------------------------------
 
-void CosocoCallbacks::buildConstraintSum(string id, vector<XVariable *> &list, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintSum(string id, vector<XVariable *> &list, XCondition &xc) {
     vector<int> coeffs;
     coeffs.assign(list.size(), 1);
     buildConstraintSum(id, list, coeffs, xc);
 }
 
 
-void CosocoCallbacks::buildConstraintSum(string id, vector<XVariable *> &list, vector<int> &origcoeffs, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintSum(string id, vector<XVariable *> &list, vector<int> &origcoeffs,
+                                                    XCondition &xc) {
     vars.clear();
     toMyVariables(list, vars);
     buildConstraintSum(id, vars, origcoeffs, xc);
 }
 
 
-void CosocoCallbacks::buildConstraintSum(string id, vec<Variable *> &variables, vector<int> &coeffs, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintSum(string id, vec<Variable *> &variables, vector<int> &coeffs, XCondition &xc) {
     string xcvar        = xc.var;
     bool   varCondition = xc.operandType == VARIABLE;
     vector2vec(coeffs);
@@ -436,7 +449,8 @@ void CosocoCallbacks::buildConstraintSum(string id, vec<Variable *> &variables, 
 }
 
 
-void CosocoCallbacks::buildConstraintSum(string id, vector<XVariable *> &list, vector<XVariable *> &coeffs, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintSum(string id, vector<XVariable *> &list, vector<XVariable *> &coeffs,
+                                                    XCondition &xc) {
     bool scalar = true;
     for(unsigned int i = 0; i < list.size(); i++) {
         if(list[i]->domain->minimum() != 0 || list[i]->domain->maximum() != 1) {
@@ -505,14 +519,14 @@ void CosocoCallbacks::buildConstraintSum(string id, vector<XVariable *> &list, v
 }
 
 
-void CosocoCallbacks::buildConstraintSum(string id, vector<Tree *> &trees, XCondition &cond) {
+void XCSP3Core::CosocoCallbacks::buildConstraintSum(string id, vector<Tree *> &trees, XCondition &cond) {
     vector<int> coeffs;
     coeffs.assign(trees.size(), 1);
     buildConstraintSum(id, trees, coeffs, cond);
 }
 
 
-void CosocoCallbacks::buildConstraintSum(string id, vector<Tree *> &trees, vector<int> &coefs, XCondition &cond) {
+void XCSP3Core::CosocoCallbacks::buildConstraintSum(string id, vector<Tree *> &trees, vector<int> &coefs, XCondition &cond) {
     vector<string> auxiliaryVariables;
     insideGroup = false;
     createAuxiliaryVariablesAndExpressions(trees, auxiliaryVariables);
@@ -524,27 +538,27 @@ void CosocoCallbacks::buildConstraintSum(string id, vector<Tree *> &trees, vecto
 }
 
 
-void CosocoCallbacks::buildConstraintAtMost(string id, vector<XVariable *> &list, int value, int k) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAtMost(string id, vector<XVariable *> &list, int value, int k) {
     FactoryConstraints::createConstraintAtMost(problem, id, toMyVariables(list), value, k);
 }
 
 
-void CosocoCallbacks::buildConstraintAtLeast(string id, vector<XVariable *> &list, int value, int k) {
+void XCSP3Core::CosocoCallbacks::buildConstraintAtLeast(string id, vector<XVariable *> &list, int value, int k) {
     FactoryConstraints::createConstraintAtLeast(problem, id, toMyVariables(list), value, k);
 }
 
 
-void CosocoCallbacks::buildConstraintExactlyK(string id, vector<XVariable *> &list, int value, int k) {
+void XCSP3Core::CosocoCallbacks::buildConstraintExactlyK(string id, vector<XVariable *> &list, int value, int k) {
     FactoryConstraints::createConstraintExactly(problem, id, toMyVariables(list), value, k);
 }
 
 
-void CosocoCallbacks::buildConstraintExactlyVariable(string id, vector<XVariable *> &list, int value, XVariable *x) {
+void XCSP3Core::CosocoCallbacks::buildConstraintExactlyVariable(string id, vector<XVariable *> &list, int value, XVariable *x) {
     FactoryConstraints::createConstraintExactlyVariable(problem, id, toMyVariables(list), value, problem->mapping[x->id]);
 }
 
 
-void CosocoCallbacks::buildConstraintNValues(string id, vector<XVariable *> &list, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintNValues(string id, vector<XVariable *> &list, XCondition &xc) {
     if(!(xc.operandType == VARIABLE && xc.op == EQ))
         throw runtime_error("c Such nValues constraint Not yes supported");
 
@@ -552,7 +566,8 @@ void CosocoCallbacks::buildConstraintNValues(string id, vector<XVariable *> &lis
 }
 
 
-void CosocoCallbacks::buildConstraintCount(string id, vector<XVariable *> &list, vector<XVariable *> &values, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCount(string id, vector<XVariable *> &list, vector<XVariable *> &values,
+                                                      XCondition &xc) {
     if(values.size() == 1) {
         vector<Tree *> trees;
         for(auto &xv : list) {
@@ -566,7 +581,7 @@ void CosocoCallbacks::buildConstraintCount(string id, vector<XVariable *> &list,
 }
 
 
-void CosocoCallbacks::buildConstraintCount(string id, vector<Tree *> &trees, vector<int> &values, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCount(string id, vector<Tree *> &trees, vector<int> &values, XCondition &xc) {
     if(values.size() == 1) {
         vector<Tree *> newtrees;
         for(auto &tree : trees) {
@@ -580,7 +595,8 @@ void CosocoCallbacks::buildConstraintCount(string id, vector<Tree *> &trees, vec
 }
 
 
-void CosocoCallbacks::buildConstraintCount(string id, vector<Tree *> &trees, vector<XVariable *> &values, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCount(string id, vector<Tree *> &trees, vector<XVariable *> &values,
+                                                      XCondition &xc) {
     // TODO WARNING
     if(values.size() == 1) {
         vector<Tree *> newtrees;
@@ -595,8 +611,8 @@ void CosocoCallbacks::buildConstraintCount(string id, vector<Tree *> &trees, vec
 }
 
 
-void CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> &list, vector<int> values, vector<int> &intOccurs,
-                                                 bool closed) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> &list, vector<int> values,
+                                                            vector<int> &intOccurs, bool closed) {
     vec<Occurs> occurs;
     for(int o : intOccurs) {
         occurs.push();
@@ -607,8 +623,8 @@ void CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> 
 }
 
 
-void CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> &list, vector<int> values,
-                                                 vector<XVariable *> &varOccurs, bool closed) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> &list, vector<int> values,
+                                                            vector<XVariable *> &varOccurs, bool closed) {
     vec<Occurs> occurs;
     for(XVariable *xv : varOccurs) {
         occurs.push();
@@ -619,8 +635,8 @@ void CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> 
 }
 
 
-void CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> &list, vector<int> values,
-                                                 vector<XInterval> &intervalOccurs, bool closed) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> &list, vector<int> values,
+                                                            vector<XInterval> &intervalOccurs, bool closed) {
     vec<Occurs> occurs;
     for(XInterval &xi : intervalOccurs) {
         occurs.push();
@@ -636,7 +652,7 @@ void CosocoCallbacks::buildConstraintCardinality(string id, vector<XVariable *> 
 // Connection constraints
 //--------------------------------------------------------------------------------------
 
-string CosocoCallbacks::createExpression(string minmax, OrderType op, vector<XVariable *> &list, string value) {
+string XCSP3Core::CosocoCallbacks::createExpression(string minmax, OrderType op, vector<XVariable *> &list, string value) {
     string o;
 
     if(op == LE)
@@ -661,7 +677,7 @@ string CosocoCallbacks::createExpression(string minmax, OrderType op, vector<XVa
 }
 
 
-void CosocoCallbacks::buildConstraintMaximum(string id, vector<Tree *> &list, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintMaximum(string id, vector<Tree *> &list, XCondition &xc) {
     if(xc.operandType == VARIABLE) {
         if(xc.op == EQ) {
             vector<string> auxiliaryVariables;
@@ -676,7 +692,7 @@ void CosocoCallbacks::buildConstraintMaximum(string id, vector<Tree *> &list, XC
     throw runtime_error("Maximum over set is not yet supported");
 }
 
-void CosocoCallbacks::buildConstraintMinimum(string id, vector<Tree *> &list, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintMinimum(string id, vector<Tree *> &list, XCondition &xc) {
     if(xc.operandType == VARIABLE) {
         if(xc.op == EQ) {
             vector<string> auxiliaryVariables;
@@ -691,7 +707,7 @@ void CosocoCallbacks::buildConstraintMinimum(string id, vector<Tree *> &list, XC
     throw runtime_error("minimum over set is not yet supported");
 }
 
-void CosocoCallbacks::buildConstraintMaximum(string id, vector<XVariable *> &list, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintMaximum(string id, vector<XVariable *> &list, XCondition &xc) {
     if(xc.operandType == VARIABLE) {
         if(xc.op == EQ) {
             toMyVariables(list, vars);
@@ -722,7 +738,7 @@ void CosocoCallbacks::buildConstraintMaximum(string id, vector<XVariable *> &lis
 }
 
 
-void CosocoCallbacks::buildConstraintMinimum(string id, vector<XVariable *> &list, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintMinimum(string id, vector<XVariable *> &list, XCondition &xc) {
     if(xc.operandType == VARIABLE) {
         if(xc.op == EQ) {
             toMyVariables(list, vars);
@@ -753,15 +769,15 @@ void CosocoCallbacks::buildConstraintMinimum(string id, vector<XVariable *> &lis
 }
 
 
-void CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &list, int startIndex, XVariable *index,
-                                             RankType rank, int value) {
+void XCSP3Core::CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &list, int startIndex, XVariable *index,
+                                                        RankType rank, int value) {
     Variable *idx = problem->mapping[index->id];
     FactoryConstraints::createConstraintElementConstant(problem, id, toMyVariables(list), idx, startIndex, value);
 }
 
 
-void CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &list, int startIndex, XVariable *index,
-                                             RankType rank, XVariable *value) {
+void XCSP3Core::CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &list, int startIndex, XVariable *index,
+                                                        RankType rank, XVariable *value) {
     if(value->id == index->id) {
         for(XVariable *x : list)
             if(x == value)
@@ -790,8 +806,8 @@ void CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &lis
 }
 
 
-void CosocoCallbacks::buildConstraintElement(string id, vector<int> &list, int startIndex, XVariable *index, RankType rank,
-                                             XVariable *value) {
+void XCSP3Core::CosocoCallbacks::buildConstraintElement(string id, vector<int> &list, int startIndex, XVariable *index,
+                                                        RankType rank, XVariable *value) {
     vec<Variable *> tmp;
     vec<vec<int>>   tuples;
     Variable       *idx = problem->mapping[index->id];
@@ -809,7 +825,8 @@ void CosocoCallbacks::buildConstraintElement(string id, vector<int> &list, int s
     FactoryConstraints::createConstraintExtension(problem, id, tmp, tuples, true, false);
 }
 
-void CosocoCallbacks::buildConstraintElement(string id, vector<int> &list, XVariable *index, int startIndex, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintElement(string id, vector<int> &list, XVariable *index, int startIndex,
+                                                        XCondition &xc) {
     vector<XVariable *> aux;
     for(int value : list) {
         string auxVar = "__av" + std::to_string(auxiliaryIdx++) + "__";
@@ -820,8 +837,8 @@ void CosocoCallbacks::buildConstraintElement(string id, vector<int> &list, XVari
     buildConstraintElement(id, aux, index, startIndex, xc);
 }
 
-void CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &list, XVariable *index, int startIndex,
-                                             XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &list, XVariable *index, int startIndex,
+                                                        XCondition &xc) {
     if(xc.op == EQ) {
         if(xc.operandType == INTEGER) {
             buildConstraintElement(id, list, startIndex, index, ANY, xc.val);
@@ -874,8 +891,9 @@ void CosocoCallbacks::buildConstraintElement(string id, vector<XVariable *> &lis
     buildConstraintElement(id, list, startIndex, index, ANY, x);
 }
 
-void CosocoCallbacks::buildConstraintElement(string id, vector<vector<int>> &matrix, int startRowIndex, XVariable *rowIndex,
-                                             int startColIndex, XVariable *colIndex, XVariable *value) {
+void XCSP3Core::CosocoCallbacks::buildConstraintElement(string id, vector<vector<int>> &matrix, int startRowIndex,
+                                                        XVariable *rowIndex, int startColIndex, XVariable *colIndex,
+                                                        XVariable *value) {
     if(startRowIndex != 0 || startColIndex != 0)
         throw runtime_error("Element int matrix with startRowIndex or StartColIndex !=0 not yet supported");
 
@@ -907,8 +925,8 @@ void CosocoCallbacks::buildConstraintElement(string id, vector<vector<int>> &mat
 }
 
 
-void CosocoCallbacks::buildConstraintElement(string id, vector<vector<XVariable *>> &matrix, int startRowIndex,
-                                             XVariable *rowIndex, int startColIndex, XVariable *colIndex, int value) {
+void XCSP3Core::CosocoCallbacks::buildConstraintElement(string id, vector<vector<XVariable *>> &matrix, int startRowIndex,
+                                                        XVariable *rowIndex, int startColIndex, XVariable *colIndex, int value) {
     if(rowIndex == colIndex) {
         if(matrix.size() != matrix[0].size())
             throw runtime_error("Problem in element matrix");
@@ -932,15 +950,15 @@ void CosocoCallbacks::buildConstraintElement(string id, vector<vector<XVariable 
 }
 
 
-void CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &list, int startIndex) {
+void XCSP3Core::CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &list, int startIndex) {
     if(startIndex != 0)
         throw runtime_error("Channel is not implemented with index != 0");
     toMyVariables(list);
     FactoryConstraints::createConstraintChannel(problem, id, vars, 0);
 }
 
-void CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &list1, int startIndex1, vector<XVariable *> &list2,
-                                             int startIndex2) {
+void XCSP3Core::CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &list1, int startIndex1,
+                                                        vector<XVariable *> &list2, int startIndex2) {
     vec<Variable *> X;
     vec<Variable *> Y;
     toMyVariables(list1, X);
@@ -949,7 +967,7 @@ void CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &lis
 }
 
 
-void CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &list, int startIndex, XVariable *value) {
+void XCSP3Core::CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &list, int startIndex, XVariable *value) {
     //  return forall(range(list.length), i -> intension(iff(list[i], eq(value, i))));
     int i = 0;
     for(XVariable *x : list) {
@@ -965,7 +983,8 @@ void CosocoCallbacks::buildConstraintChannel(string id, vector<XVariable *> &lis
 //--------------------------------------------------------------------------------------
 
 
-void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<XVariable *> &origins, vector<int> &lengths, bool zeroIgnored) {
+void XCSP3Core::CosocoCallbacks::buildConstraintNoOverlap(string id, vector<XVariable *> &origins, vector<int> &lengths,
+                                                          bool zeroIgnored) {
     if(!zeroIgnored)
         throw runtime_error("Nooverlap with zeroIgnored not yet supported");
 
@@ -975,8 +994,8 @@ void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<XVariable *> &o
             FactoryConstraints::createConstraintNoOverlap(problem, id, vars[i], vars[j], lengths[i], lengths[j]);
 }
 
-void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<XVariable *> &origins, vector<XVariable *> &lengths,
-                                               bool zeroIgnored) {
+void XCSP3Core::CosocoCallbacks::buildConstraintNoOverlap(string id, vector<XVariable *> &origins, vector<XVariable *> &lengths,
+                                                          bool zeroIgnored) {
     if(!zeroIgnored)
         throw runtime_error("K dim Nooverlap with zeroIgnored not yet supported");
     for(unsigned int i = 0; i < origins.size(); i++)
@@ -989,8 +1008,8 @@ void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<XVariable *> &o
         }
 }
 
-void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<vector<XVariable *>> &origins,
-                                               vector<vector<XVariable *>> &lengths, bool zeroIgnored) {
+void XCSP3Core::CosocoCallbacks::buildConstraintNoOverlap(string id, vector<vector<XVariable *>> &origins,
+                                                          vector<vector<XVariable *>> &lengths, bool zeroIgnored) {
     if(!zeroIgnored)
         throw runtime_error("K dim Nooverlap with zeroIgnored not yet supported");
 
@@ -1012,8 +1031,8 @@ void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<vector<XVariabl
 }
 
 
-void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<vector<XVariable *>> &origins, vector<vector<int>> &lengths,
-                                               bool zeroIgnored) {
+void XCSP3Core::CosocoCallbacks::buildConstraintNoOverlap(string id, vector<vector<XVariable *>> &origins,
+                                                          vector<vector<int>> &lengths, bool zeroIgnored) {
     if(!zeroIgnored)
         throw runtime_error("K dim Nooverlap with zeroIgnored not yet supported");
     assert(origins.size() == lengths.size() && origins[0].size() == 2);
@@ -1081,8 +1100,8 @@ void CosocoCallbacks::buildConstraintNoOverlap(string id, vector<vector<XVariabl
 }
 
 
-void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins, vector<int> &lengths,
-                                                vector<int> &heights, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins, vector<int> &lengths,
+                                                           vector<int> &heights, XCondition &xc) {
     vars.clear();
     vec<int> h, l;
     vector2vec(lengths);
@@ -1097,8 +1116,8 @@ void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &
 }
 
 
-void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins, vector<int> &lengths,
-                                                vector<XVariable *> &varHeights, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins, vector<int> &lengths,
+                                                           vector<XVariable *> &varHeights, XCondition &xc) {
     vars.clear();
     vec<int>        l;
     vec<Variable *> myvarHeights;
@@ -1115,8 +1134,8 @@ void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &
 }
 
 
-void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins, vector<XVariable *> &varlengths,
-                                                vector<int> &h, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins,
+                                                           vector<XVariable *> &varlengths, vector<int> &h, XCondition &xc) {
     vars.clear();
     vec<int>        heights;
     vec<Variable *> myvarwidths;
@@ -1132,8 +1151,9 @@ void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &
 }
 
 
-void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins, vector<XVariable *> &varwidths,
-                                                vector<XVariable *> &varheights, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &origins,
+                                                           vector<XVariable *> &varwidths, vector<XVariable *> &varheights,
+                                                           XCondition &xc) {
     vars.clear();
     vec<Variable *> myvarwidths, myvarheights;
 
@@ -1149,7 +1169,8 @@ void CosocoCallbacks::buildConstraintCumulative(string id, vector<XVariable *> &
 }
 
 
-void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes, XCondition &cond) {
+void XCSP3Core::CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes,
+                                                           XCondition &cond) {
     vars.clear();
     toMyVariables(list, vars);
     if(Variable::haveSameDomainType(vars) == false) {
@@ -1170,8 +1191,8 @@ void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &
 }
 
 
-void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes, vector<int> &capacities,
-                                                bool load) {
+void XCSP3Core::CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes,
+                                                           vector<int> &capacities, bool load) {
     vec<int> s, c;
     vector2vec(sizes);
     vals.copyTo(s);
@@ -1194,8 +1215,8 @@ void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &
         FactoryConstraints::createConstraintBinPacking(problem, id, vars, s, c);
 }
 
-void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes,
-                                                vector<XVariable *> &capacities, bool load) {
+void XCSP3Core::CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes,
+                                                           vector<XVariable *> &capacities, bool load) {
     vec<int> s;
     vector2vec(sizes);
     vals.copyTo(s);
@@ -1223,8 +1244,8 @@ void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &
     }
 }
 
-void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes,
-                                                vector<XCondition> &conditions, int startindex) {
+void XCSP3Core::CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &list, vector<int> &sizes,
+                                                           vector<XCondition> &conditions, int startindex) {
     for(XCondition &xc : conditions) {
         if(xc.operandType != VARIABLE && xc.op != EQ)
             throw std::runtime_error("Bin packing with all condiions not EQ=VAR is not yet implemented");
@@ -1243,7 +1264,7 @@ void CosocoCallbacks::buildConstraintBinPacking(string id, vector<XVariable *> &
 // Instantiation constraint
 //--------------------------------------------------------------------------------------
 
-void CosocoCallbacks::buildConstraintInstantiation(string id, vector<XVariable *> &list, vector<int> &values) {
+void XCSP3Core::CosocoCallbacks::buildConstraintInstantiation(string id, vector<XVariable *> &list, vector<int> &values) {
     for(unsigned int i = 0; i < list.size(); i++) {
         vec<int> value;
         if(values[i] == STAR)
@@ -1254,12 +1275,13 @@ void CosocoCallbacks::buildConstraintInstantiation(string id, vector<XVariable *
 }
 
 
-void CosocoCallbacks::buildConstraintPrecedence(string id, vector<XVariable *> &list, vector<int> values, bool covered) {
+void XCSP3Core::CosocoCallbacks::buildConstraintPrecedence(string id, vector<XVariable *> &list, vector<int> values,
+                                                           bool covered) {
     toMyVariables(list);
     FactoryConstraints::createConstraintPrecedence(problem, id, vars, vector2vec(values), covered);
 }
 
-void CosocoCallbacks::buildConstraintPrecedence(string id, vector<XVariable *> &list, bool covered) {
+void XCSP3Core::CosocoCallbacks::buildConstraintPrecedence(string id, vector<XVariable *> &list, bool covered) {
     toMyVariables(list);
     std::set<int> values;
     for(Variable *x : vars) {
@@ -1270,15 +1292,16 @@ void CosocoCallbacks::buildConstraintPrecedence(string id, vector<XVariable *> &
     FactoryConstraints::createConstraintPrecedence(problem, id, vars, tmp, covered);
 }
 
-void CosocoCallbacks::buildConstraintKnapsack(string id, vector<XVariable *> &list, vector<int> &weights, vector<int> &profits,
-                                              XCondition weightsCondition, XCondition &profitCondition) {
+void XCSP3Core::CosocoCallbacks::buildConstraintKnapsack(string id, vector<XVariable *> &list, vector<int> &weights,
+                                                         vector<int> &profits, XCondition weightsCondition,
+                                                         XCondition &profitCondition) {
     buildConstraintSum(id, list, weights, weightsCondition);
     buildConstraintSum(id, list, profits, profitCondition);
 }
 
 
-void CosocoCallbacks::buildConstraintFlow(string id, vector<XVariable *> &list, vector<int> &balance, vector<int> &weights,
-                                          vector<vector<int>> &arcs, XCondition &xc) {
+void XCSP3Core::CosocoCallbacks::buildConstraintFlow(string id, vector<XVariable *> &list, vector<int> &balance,
+                                                     vector<int> &weights, vector<vector<int>> &arcs, XCondition &xc) {
     std::set<int> set;
     toMyVariables(list);
     for(auto &arc : arcs) {
@@ -1315,7 +1338,7 @@ void CosocoCallbacks::buildConstraintFlow(string id, vector<XVariable *> &list, 
 // Objectives
 //--------------------------------------------------------------------------------------
 
-void CosocoCallbacks::buildObjectiveMinimizeExpression(string expr) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimizeExpression(string expr) {
     string tmp = "le(" + expr + ",0)";
     buildConstraintIntension("objective", new XCSP3Core::Tree(tmp));
 
@@ -1326,7 +1349,7 @@ void CosocoCallbacks::buildObjectiveMinimizeExpression(string expr) {
 }
 
 
-void CosocoCallbacks::buildObjectiveMaximizeExpression(string expr) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximizeExpression(string expr) {
     string tmp = "ge(" + expr + ",0)";   // Fake value
     buildConstraintIntension("objective", new XCSP3Core::Tree(tmp));
     auto *po = static_cast<OptimizationProblem *>(problem);
@@ -1336,7 +1359,7 @@ void CosocoCallbacks::buildObjectiveMaximizeExpression(string expr) {
     po->addObjectiveLB(oc, true);
 }
 
-void CosocoCallbacks::buildObjectiveMinimizeVariable(XVariable *x) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimizeVariable(XVariable *x) {
     FactoryConstraints::createConstraintUnaryLE(problem, "", problem->mapping[x->id], 0);
     auto *po = static_cast<OptimizationProblem *>(problem);
     po->type = OptimisationType::Minimize;
@@ -1344,7 +1367,7 @@ void CosocoCallbacks::buildObjectiveMinimizeVariable(XVariable *x) {
     po->addObjectiveUB(oc, true);
 }
 
-void CosocoCallbacks::buildObjectiveMaximizeVariable(XVariable *x) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximizeVariable(XVariable *x) {
     FactoryConstraints::createConstraintUnaryGE(problem, "", problem->mapping[x->id], 0);
     auto *po = static_cast<OptimizationProblem *>(problem);
     po->type = OptimisationType::Maximize;
@@ -1353,21 +1376,22 @@ void CosocoCallbacks::buildObjectiveMaximizeVariable(XVariable *x) {
 }
 
 
-void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XVariable *> &list) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XVariable *> &list) {
     vector<int> coeffs;
     coeffs.assign(list.size(), 1);
     buildObjectiveMinimize(type, list, coeffs);
 }
 
 
-void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<XVariable *> &list) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<XVariable *> &list) {
     vector<int> coeffs;
     coeffs.assign(list.size(), 1);
     buildObjectiveMaximize(type, list, coeffs);
 }
 
 
-void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vec<Variable *> &variables, vector<int> &origcoeffs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vec<Variable *> &variables,
+                                                        vector<int> &origcoeffs) {
     auto *po = static_cast<OptimizationProblem *>(problem);
     po->type = OptimisationType::Minimize;
 
@@ -1412,7 +1436,8 @@ void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vec<Varia
 }
 
 
-void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XVariable *> &list, vector<int> &origcoeffs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XVariable *> &list,
+                                                        vector<int> &origcoeffs) {
     for(int core = 0; core < nbcores; core++) {
         toMyVariables(list, vars);
         buildObjectiveMinimize(type, vars, origcoeffs);
@@ -1420,7 +1445,8 @@ void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XV
 }
 
 
-void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vec<Variable *> &variables, vector<int> &origcoeffs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vec<Variable *> &variables,
+                                                        vector<int> &origcoeffs) {
     auto *po = static_cast<OptimizationProblem *>(problem);
     po->type = OptimisationType::Maximize;
 
@@ -1452,13 +1478,15 @@ void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vec<Varia
 }
 
 
-void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<XVariable *> &list, vector<int> &origcoeffs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<XVariable *> &list,
+                                                        vector<int> &origcoeffs) {
     toMyVariables(list, vars);
     buildObjectiveMaximize(type, vars, origcoeffs);
 }
 
 
-void CosocoCallbacks::createAuxiliaryVariablesAndExpressions(vector<Tree *> &trees, vector<string> &auxiliaryVariables) {
+void XCSP3Core::CosocoCallbacks::createAuxiliaryVariablesAndExpressions(vector<Tree *> &trees,
+                                                                        vector<string> &auxiliaryVariables) {
     set<int>                   values;
     std::map<std::string, int> tuple;
 
@@ -1505,7 +1533,7 @@ void CosocoCallbacks::createAuxiliaryVariablesAndExpressions(vector<Tree *> &tre
 }
 
 
-void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<Tree *> &trees, vector<int> &coefs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<Tree *> &trees, vector<int> &coefs) {
     vector<string> auxiliaryVariables;
     startToParseObjective = false;
     createAuxiliaryVariablesAndExpressions(trees, auxiliaryVariables);
@@ -1518,7 +1546,7 @@ void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<Tr
 }
 
 
-void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<Tree *> &trees, vector<int> &coefs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<Tree *> &trees, vector<int> &coefs) {
     vector<string> auxiliaryVariables;
 
     startToParseObjective = false;
@@ -1532,7 +1560,8 @@ void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<Tr
 }
 
 
-void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XVariable *> &list, vector<XVariable *> &coefs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XVariable *> &list,
+                                                        vector<XVariable *> &coefs) {
     auto *po = static_cast<OptimizationProblem *>(problem);
     po->type = OptimisationType::Minimize;
     switch(type) {
@@ -1560,7 +1589,8 @@ void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<XV
 }
 
 
-void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<XVariable *> &list, vector<XVariable *> &coefs) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<XVariable *> &list,
+                                                        vector<XVariable *> &coefs) {
     auto *po = static_cast<OptimizationProblem *>(problem);
     po->type = OptimisationType::Maximize;
     toMyVariables(list);
@@ -1583,18 +1613,20 @@ void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<XV
 }
 
 
-void CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<Tree *> &trees) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMinimize(ExpressionObjective type, vector<Tree *> &trees) {
     vector<int> coeffs;
     coeffs.assign(trees.size(), 1);
     buildObjectiveMinimize(type, trees, coeffs);
 }
 
 
-void CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<Tree *> &trees) {
+void XCSP3Core::CosocoCallbacks::buildObjectiveMaximize(ExpressionObjective type, vector<Tree *> &trees) {
     vector<int> coeffs;
     coeffs.assign(trees.size(), 1);
     buildObjectiveMaximize(type, trees, coeffs);
 }
 
 
-void CosocoCallbacks::buildAnnotationDecision(vector<XVariable *> &list) { toMyVariables(list, decisionVariables[0]); }
+void XCSP3Core::CosocoCallbacks::buildAnnotationDecision(vector<XVariable *> &list) { toMyVariables(list, decisionVariables[0]); }
+
+#endif /* USE_XCSP3 */

--- a/solver/utils/ManageIntension.cc
+++ b/solver/utils/ManageIntension.cc
@@ -1,11 +1,12 @@
 //
 // Created by audemard on 30/03/24.
 //
-
+#ifdef USE_XCSP3
 #include <utility>
 
 #include "CosocoCallbacks.h"
 using namespace XCSP3Core;
+using namespace Cosoco;
 
 void replace_all_occurrences(std::string &input, const std::string &replace_word, const std::string &replace_by) {
     size_t pos = input.find(replace_word);
@@ -721,3 +722,5 @@ void ManageIntension::createPrimitives() {
     patterns.push(new PNary4(callbacks));
     // patterns.push(new PNary5(callbacks));
 }
+
+#endif /* USE_XCSP3 */

--- a/utils/Constants.h
+++ b/utils/Constants.h
@@ -1,0 +1,12 @@
+#pragma once
+#ifndef COSOCO_CONSTANTS
+#define COSOCO_CONSTANTS
+
+#ifdef USE_XCSP3
+#include "XCSP3Constants.h"
+#else
+#include <climits>
+#define STAR INT_MAX
+#endif
+
+#endif

--- a/utils/Utils.cc
+++ b/utils/Utils.cc
@@ -1,9 +1,9 @@
 //
 // Created by audemard on 16/04/24.
 //
+#include "Utils.h"
 
 #include <sstream>
-#include <vector>
 
 std::vector<std::string> &split1(const std::string &s, char delim, std::vector<std::string> &elems) {
     std::stringstream ss(s);

--- a/utils/Utils.h
+++ b/utils/Utils.h
@@ -1,11 +1,13 @@
 //
 // Created by audemard on 10/11/2015.
 //
-#include <sstream>
+#pragma once
 
 #ifndef COSOCO_UTILS_H
 #define COSOCO_UTILS_H
 
+#include <string>
+#include <vector>
 
 template <class T>
 const T &max(const T &a, const T &b) {
@@ -25,6 +27,11 @@ inline double drand(double &seed) {
 // Returns a random integer 0 <= x < size. Seed must never be 0.
 inline int irand(double &seed, int size) { return (int)(drand(seed) * size); }
 
+std::vector<std::string> &split1(const std::string &s, char delim, std::vector<std::string> &elems);
+std::vector<std::string>  split1(const std::string &s, char delim);
+
+#ifdef USE_XCSP3
+#include "XCSP3TreeNode.h"
 inline bool nodeContainsVar(XCSP3Core::Node *n, std::string name) {
     if(n->type == XCSP3Core::OVAR) {
         auto *nv = dynamic_cast<XCSP3Core::NodeVariable *>(n);
@@ -38,8 +45,8 @@ inline bool nodeContainsVar(XCSP3Core::Node *n, std::string name) {
             return true;
     return false;
 }
-std::vector<std::string> &split1(const std::string &s, char delim, std::vector<std::string> &elems);
-std::vector<std::string>  split1(const std::string &s, char delim);
+
+#endif /* USE_XCSP3 */
 
 
 #endif   // COSOCO_UTILS_H


### PR DESCRIPTION
In this commit, a few things were made: 
* a compiler definition USE_XCSP3 is used to know if we are allowed to use the XCSP3 parser headers
* a cmake option 'NO_XCSP3' defined such that by default, XCSP3 is still used
* define the cosoco binary only if XCSP3 is allowed
* define the file 'utils/Constants.h' that provide the definition of 'STAR' if XCSP3 is not allowed, or include the XCSP3Constants.h to retrieve the definition of 'STAR'
* provide a first implementation of the build-lib.sh script, meant to build the static library that has no dependency to libxml2 or XCSP3-Parser