### PR TITLE
Fix build with GCC 15: qualify string as std::string in MDD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cmake_install.cmake
 cmake-build-debug
 CMakeFiles
 CMakeCache.txt
+/Makefile
 
 #
 lib

--- a/constraints/extensions/structures/MDD.cc
+++ b/constraints/extensions/structures/MDD.cc
@@ -14,7 +14,7 @@ using namespace Cosoco;
 
 MDD::MDD(vec<XCSP3Core::XTransition *> &transitions, vec<Variable *> &scope) {
     std::map<std::string, MDDNode *> nodes;
-    std::set<string>                 possibleRoots, possibleLeaves;
+    std::set<std::string>            possibleRoots, possibleLeaves;
     std::set<std::string>::iterator  it;
     unsigned int                     nb = 0;
     for(XCSP3Core::XTransition *tr : transitions) {
@@ -31,7 +31,7 @@ MDD::MDD(vec<XCSP3Core::XTransition *> &transitions, vec<Variable *> &scope) {
     assert(possibleLeaves.size() == 1);
     assert(possibleRoots.size() == 1);
 
-    std::set<string> nodeNames;
+    std::set<std::string> nodeNames;
     for(XCSP3Core::XTransition *tr : transitions) {
         nodeNames.insert(tr->from);
         nodeNames.insert(tr->to);
@@ -76,7 +76,7 @@ MDD::~MDD() {
 //----------------------------------------------
 
 
-MDD *MDD::buildFromAutomata(vec<Variable *> &scope, string start, std::vector<string> &finals,
+MDD *MDD::buildFromAutomata(vec<Variable *> &scope, std::string start, std::vector<std::string> &finals,
                             vec<XCSP3Core::XTransition *> &transitions) {
     // Build Map state-> possible state
     std::map<std::string, vec<XCSP3Core::XTransition *> *> nextTransitions;

--- a/constraints/extensions/structures/MDD.h
+++ b/constraints/extensions/structures/MDD.h
@@ -42,7 +42,7 @@ class MDD {
     MDD(vec<XCSP3Core::XTransition *> &transitions, vec<Variable *> &scope);
     virtual ~MDD();
 
-    static MDD *buildFromAutomata(vec<Variable *> &scope, string start, std::vector<string> &finals,
+    static MDD *buildFromAutomata(vec<Variable *> &scope, std::string start, std::vector<std::string> &finals,
                                   vec<XCSP3Core::XTransition *> &transitions);
 };
 }   // namespace Cosoco


### PR DESCRIPTION
### Problem

`cosoco` no longer builds with recent GCC / current `XCSP3-CPP-Parser`:

```
constraints/extensions/structures/MDD.h:45:59: error: 'string' has not been declared
constraints/extensions/structures/MDD.cc:17:14: error: 'string' was not declared in this scope; did you mean 'std::string'?
```

`MDD.h` and `MDD.cc` use unqualified `string`, but neither declares `using namespace std`. It used to compile only because `XCSP3Constraint.h` transitively leaked one; the current parser no longer does, so every dependent translation unit fails (`MDDExtension.cc`, `Constraint.cc`, ...).

### Fix

Qualify the four occurrences as `std::string`. **No semantic change** — the type was already `std::string` in practice. `<string>` was already included.

The second commit adds the cmake-generated root `Makefile` to `.gitignore`: `build.sh` configures in-source, so it lands at the repo root as untracked, next to `CMakeCache.txt` / `CMakeFiles` / `cmake_install.cmake` which are already ignored. Anchored as `/Makefile` so a hand-written Makefile in a subdirectory is not silently ignored. Happy to drop this commit if you would rather keep the PR minimal.

### Testing

Built on Ubuntu, GCC 15.2, LibXml2 2.14.5, against `XCSP3-CPP-Parser` at `e645e05`.

Solves the instances shipped with the parser:

- `instances/tsp-25-843.xml` → `s SATISFIABLE` (5.8s)
- an 8-queens CSP (`allDifferent` + grouped `intension`) → `s SATISFIABLE`, solution verified independently

Unrelated observation, reported here only in case it is useful: `instances/obj.xml` segfaults, but the fault is in the parser, not cosoco — the instance contains `ne(sub(x[1],x[2]))`, a unary `ne`, and `XCSP3Core::NodeNE::evaluate` reads a second operand that does not exist. With the arity corrected, cosoco returns `s OPTIMUM FOUND`.