### PR TITLE
Rename the PyPI distribution to cosoco and bump to 2.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
 
       - name: Install the wheel of this runner and solve an instance
         run: |
-          python -m pip install dist/cosoco_bin-*-manylinux_2_17_x86_64.whl
+          python -m pip install dist/cosoco-*-manylinux_2_17_x86_64.whl
           cosoco .github/smoke.xml -model=2 | tee out.txt
           grep -q '^s SATISFIABLE' out.txt
           python -c "import cosoco_bin, os; assert os.access(cosoco_bin.PATH, os.X_OK), cosoco_bin.PATH"

--- a/main/Main.cc
+++ b/main/Main.cc
@@ -24,7 +24,7 @@ vec<AbstractSolver *> solvers;
 bool   optimize = false;
 double realTimeStart;
 
-string version("2.6");
+string version("2.6.1");
 
 void displayProblemStatistics(Problem *solvingProblem, double initial_time);
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,4 +1,4 @@
-# cosoco-bin
+# cosoco
 
 [cosoco](https://github.com/xcsp3team/cosoco) is a compact constraint solver,
 written in C++, that reads [XCSP3](https://xcsp.org) instances.
@@ -8,7 +8,7 @@ of the wheel. It contains no binding: cosoco is meant to be run as a separate
 process.
 
 ```bash
-pip install cosoco-bin
+pip install cosoco
 cosoco instance.xml -model=2
 ```
 

--- a/python/cosoco_bin/__init__.py
+++ b/python/cosoco_bin/__init__.py
@@ -21,7 +21,7 @@ __all__ = ["PATH", "main"]
 PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "cosoco")
 
 try:
-    __version__ = _version("cosoco-bin")
+    __version__ = _version("cosoco")
 except PackageNotFoundError:  # imported from a source tree, not installed
     __version__ = "unknown"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "cosoco-bin"
+name = "cosoco"
 dynamic = ["version"]
 description = "The cosoco constraint solver, shipped as a prebuilt executable"
 readme = "README.md"


### PR DESCRIPTION
Brings `main` up to date with the **2.6.1** release (already live on [PyPI](https://pypi.org/project/cosoco/)). Two commits:

- **Rename the PyPI distribution from `cosoco-bin` to `cosoco`.** The import package stays `cosoco_bin` and the installed command stays `cosoco`; only the distribution name on PyPI changes, so `pip install cosoco` works and the wheels are named `cosoco-<version>-*`.
- **Bump the version to 2.6.1** (`main/Main.cc`), so the binary and the package report the same version.

### Where the version number lives

There is a **single** hardcoded version in the repository, plus the git tag. To release version `X.Y.Z`, change these two, and make sure they match:

1. **`main/Main.cc`, line 27** — `string version("X.Y.Z");`. This is the source of truth: the solver prints it, and (outside CI) `setup.py` reads it.
2. **The git tag** — `vX.Y.Z`. This is what actually sets the published version: in CI the workflow takes `COSOCO_BIN_VERSION` from the tag (`${GITHUB_REF_NAME#v}`), which `setup.py` uses for the wheels, overriding `Main.cc`.

Nothing else needs editing — `python/pyproject.toml` declares `dynamic = ["version"]`, `python/setup.py` derives it (from the tag, else from `Main.cc`), and `python/cosoco_bin/__init__.py` reads it back from the installed package metadata.

### Making a new release

A release is cut from a `v*` tag; the workflow `.github/workflows/release.yml` does the rest.

1. **Bump the version** in `main/Main.cc` (see above) and commit.
2. **Check the switch is armed:** the repository variable `PUBLISH_TO_PYPI` must be `true` (Settings → Secrets and variables → Actions → Variables). It keeps a tag from publishing before a trusted publisher exists; it is already set.
3. **Tag and push:**
   ```bash
   git tag -a vX.Y.Z -m "cosoco X.Y.Z"
   git push origin vX.Y.Z          # the tag must match v*
   ```
   (A push that *touches* `.github/workflows/` needs a credential with the `workflow` scope — e.g. over SSH; ordinary commits and tags do not.)
4. On that tag the workflow then:
   - builds the 6 binaries — Linux x86_64 and aarch64, macOS x86_64 and arm64 (the static Linux binary serves both glibc and musl);
   - builds the 6 wheels `cosoco-X.Y.Z-py3-none-<platform>.whl`;
   - creates a GitHub release with the binaries, the wheels and `SHA256SUMS`;
   - publishes the wheels to PyPI through **Trusted Publishing** (OIDC via the `pypi` environment — no token stored anywhere).
5. **Check:** the run is green, including the **PyPI** job, and `https://pypi.org/project/cosoco/X.Y.Z/` is live.

### After merging

This branch can be deleted once merged — it will not be reused (the **Delete branch** button after merge, or `gh pr merge --delete-branch`).
